### PR TITLE
Refresh Cargo.lock for 0.2.6 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "python-ron"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "pyo3",
  "ron",


### PR DESCRIPTION
I believe the issue with the release was that the Cargo.toml had version 0.2.6, but the checked in Cargo.lock (checking in the lockfile is the modern recommended pattern) set the expected version to 0.2.5, so the maturin `--locked` check failed. Updating the lock file should fix this. 

After making a version bump running: 

```bash
cargo update --workspace
``` 

should prevent this error from occurring again. 